### PR TITLE
Make logout throw error on bad timing

### DIFF
--- a/KataLogInLogOutSwift/KataLogInLogOut.swift
+++ b/KataLogInLogOutSwift/KataLogInLogOut.swift
@@ -1,8 +1,7 @@
-import Foundation
 import Combine
+import Foundation
 
 class KataLogInLogOut {
-
     private let clock: Clock
 
     init(clock: Clock) {
@@ -23,9 +22,11 @@ class KataLogInLogOut {
         }.eraseToAnyPublisher()
     }
 
-    func logOut() -> Bool {
+    func logOut() -> AnyPublisher<Void, LogOutError> {
         let nowInSeconds = Int(clock.now.timeIntervalSince1970)
         return nowInSeconds % 2 == 0
+            ? Empty(completeImmediately: true).setFailureType(to: LogOutError.self).eraseToAnyPublisher()
+            : Fail(outputType: Void.self, failure: LogOutError.invalidTime).eraseToAnyPublisher()
     }
 
     private func containsInvalidChars(_ username: String) -> Bool {
@@ -39,14 +40,8 @@ class KataLogInLogOut {
 
 enum LogInError: Error, Equatable {
     case invalidUsername, invalidCredentials
+}
 
-    static func == (lhs: LogInError, rhs: LogInError) -> Bool {
-        switch (lhs, rhs) {
-        case (.invalidUsername, .invalidUsername),
-             (.invalidCredentials, .invalidCredentials):
-            return true
-        default:
-            return false
-        }
-    }
+enum LogOutError: Error {
+    case invalidTime
 }

--- a/KataLogInLogOutSwift/Presenter.swift
+++ b/KataLogInLogOutSwift/Presenter.swift
@@ -31,12 +31,19 @@ class Presenter {
     }
 
     func didTapLogOutButton() {
-        if kata.logOut() {
-            view.hideLogOutForm()
-            view.showLogInForm()
-        } else {
-            view.showError(message: "Log out error")
-        }
+        kata.logOut()
+            .receive(on: RunLoop.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                guard let self = self else { return }
+                switch completion {
+                case .finished:
+                    self.view.hideLogOutForm()
+                    self.view.showLogInForm()
+                case .failure:
+                    self.view.showError(message: "Log out error")
+                }
+            }, receiveValue: { _ in })
+            .store(in: &subscriptions)
     }
 }
 

--- a/KataLogInLogOutSwiftTests/KataLogInLogOutTests.swift
+++ b/KataLogInLogOutSwiftTests/KataLogInLogOutTests.swift
@@ -57,20 +57,20 @@ class KataLogInLogOutTests: XCTestCase {
         expect(result.first!).to(equal(KataLogInLogOutTests.anyValidUsername))
     }
 
-    func testReturnsAnErrorIfTheSecondWhenTheLogOutIsPerformedIsOdd() {
+    func testReturnsAnErrorIfTheSecondWhenTheLogOutIsPerformedIsOdd() throws {
         givenNowIs(Date(timeIntervalSince1970: 3))
 
         let result = kata.logOut()
 
-        expect(result).to(beFalse())
+        expect { try result.get() }.to(throwError(LogOutError.invalidTime))
     }
 
-    func testReturnsSuccessIfTheSecondWhenTheLogOutIsPerformedIsEven() {
+    func testReturnsSuccessIfTheSecondWhenTheLogOutIsPerformedIsEven() throws {
         givenNowIs(Date(timeIntervalSince1970: 2))
 
-        let result = kata.logOut()
+        let result: [Void] = try kata.logOut().get()
 
-        expect(result).to(beTrue())
+        expect(result).to(beEmpty())
     }
 
     private func givenNowIs(_ date: Date) {

--- a/KataLogInLogOutSwiftTests/PresenterTests.swift
+++ b/KataLogInLogOutSwiftTests/PresenterTests.swift
@@ -36,7 +36,7 @@ class PresenterTests: XCTestCase {
     }
 
     func testShowsACouldNotPerformLogOutIfTheLogOutProcessFailed() {
-        givenTheLogOutProcessReturns(false)
+        givenTheLogOutProcessReturns(.fail(.invalidTime))
 
         presenter.didTapLogOutButton()
 
@@ -53,7 +53,7 @@ class PresenterTests: XCTestCase {
     }
 
     func testHidesTheLogOutFormAndShowsTheLogInFormIfTheLogOutProcessFinishProperly() {
-        givenTheLogOutProcessReturns(true)
+        givenTheLogOutProcessReturns(.just(()))
 
         presenter.didTapLogOutButton()
 
@@ -65,7 +65,7 @@ class PresenterTests: XCTestCase {
         kata.mockedLogInResult = result
     }
 
-    private func givenTheLogOutProcessReturns(_ result: Bool) {
+    private func givenTheLogOutProcessReturns(_ result: AnyPublisher<Void, LogOutError>) {
         kata.mockedLogOutResult = result
     }
 }
@@ -73,7 +73,7 @@ class PresenterTests: XCTestCase {
 class MockKataLogInLogOut: KataLogInLogOut {
 
     var mockedLogInResult: AnyPublisher<String, LogInError>!
-    var mockedLogOutResult: Bool!
+    var mockedLogOutResult: AnyPublisher<Void, LogOutError>!
 
     init() {
         super.init(clock: Clock())
@@ -83,7 +83,7 @@ class MockKataLogInLogOut: KataLogInLogOut {
         return mockedLogInResult
     }
 
-    override func logOut() -> Bool {
+    override func logOut() -> AnyPublisher<Void, LogOutError> {
         return mockedLogOutResult
     }
 }

--- a/KataLogInLogOutSwiftTests/Utils/AnyPublisher+Utils.swift
+++ b/KataLogInLogOutSwiftTests/Utils/AnyPublisher+Utils.swift
@@ -22,7 +22,8 @@ extension AnyPublisher {
         var error: Error?
     
         waitUntil(timeout: timeout) { done in
-            self.sink(receiveCompletion: {
+            self.receive(on: RunLoop.main)
+                .sink(receiveCompletion: {
                 if case let .failure(receivedError) = $0 {
                     error = receivedError
                 }


### PR DESCRIPTION
## Goals 

Replace `logOut` current implementation with something analogous to the `logIn` method.

## Rationale

The `logOut` method is currently returning a boolean indicating if the user is able to `logOut` or not. It can also be understood as a success return code, `true` on `logOut` success `false` otherwise. Caveats of this approach are:

* If we understand this as a permission checking function, the name of the operation is not very descriptive,  something like `canDoALogOut` will work better
* If we understand the resulting boolean as a success code, swift has better mechanisms of doing so in the way of error management
* What are our client's intentions? Does it want to check if the user can do a logOut? Does it want to do a `logOut`?
* The implementation is synchronous, which is quite unlikely for a real use case. 

## Implementation

The `logOut` implementation in this PR, returns an `AnyPublisher<Void, LogOutError>` completing with an error in case of failure, by doing so: we make clear the intent of this use case, make it async by default, we take advantage of the Swift language features, and in general, make this method easier to extend in the future. 

